### PR TITLE
Updated uploadify.css to add more specificity to tabNavigation selectors

### DIFF
--- a/css/uploadify.css
+++ b/css/uploadify.css
@@ -65,14 +65,14 @@ THE SOFTWARE.
 /* position flash button above css button */
 .UploadifyField .object_wrapper {position:relative; z-index:10; }
 
-div.tabNavigation { padding:5px 0 0 0; background:transparent;width:601px; }
-div.tabNavigation label {font-size:14px !important;display:block;padding-top:0px;float:left;}
-div.tabNavigation ul.navigation, #tabs ul.navigation li { margin:0; list-style:none;}
-div.tabNavigation ul.navigation { background:transparent; padding:0;}
-div.tabNavigation ul.navigation li { float:right; margin:0 0 -1px 0; font-size:12px; }
-div.tabNavigation ul.navigation li a { text-decoration:none; outline:0; display:block; float:left; padding:3px 10px; background:#aaa; margin:0 1px; color:#fff; border:1px solid #aaa; }
-div.tabNavigation ul.navigation li a:hover { background:#bbb; text-decoration:none; }
-div.tabNavigation ul.navigation li a.selected { background:#e9e9e9; color:#777; border-color:#aaa; border-bottom-color:#e9e9e9; }
+div.UploadifyField div.tabNavigation { padding:5px 0 0 0; background:transparent;width:601px; }
+div.UploadifyField div.tabNavigation label {font-size:14px !important;display:block;padding-top:0px;float:left;}
+div.UploadifyField div.tabNavigation ul.navigation, #tabs ul.navigation li { margin:0; list-style:none;}
+div.UploadifyField div.tabNavigation ul.navigation { background:transparent; padding:0;}
+div.UploadifyField div.tabNavigation ul.navigation li { float:right; margin:0 0 -1px 0; font-size:12px; }
+div.UploadifyField div.tabNavigation ul.navigation li a { text-decoration:none; outline:0; display:block; float:left; padding:3px 10px; background:#aaa; margin:0 1px; color:#fff; border:1px solid #aaa; }
+div.UploadifyField div.tabNavigation ul.navigation li a:hover { background:#bbb; text-decoration:none; }
+div.UploadifyField div.tabNavigation ul.navigation li a.selected { background:#e9e9e9; color:#777; border-color:#aaa; border-bottom-color:#e9e9e9; }
 .horizontal_tabs {padding-top:0px;margin-top:-3px;}
 .horizontal_tab {min-height:40px;}
 


### PR DESCRIPTION
The uploadify.css floats tabNavigation elements to the right. When using Uploadify with unclechees/Tabs it would float all tabs to the right not just the ones in the Uploadify interface.
