### PR TITLE
Uploadify in sapphire post-2.4 is broken

### DIFF
--- a/code/UploadifyField.php
+++ b/code/UploadifyField.php
@@ -308,10 +308,10 @@ abstract class UploadifyField extends FormField
 			$u = new Upload();
 			$u->loadIntoFile($_FILES['Filedata'], $file, $upload_folder);
 			$file->write();
-			echo $file->ID;
+			return $file->ID;
 		} 
 		else {
-			echo ' '; // return something or SWFUpload won't fire uploadSuccess
+			return ' '; // return something or SWFUpload won't fire uploadSuccess
 		}
 	}
 	


### PR DESCRIPTION
because HTTPResponse in post-2.4 introduced Content-Length header which doesn't work if you use 'echo' command. 
