### PR TITLE
loadUploadedImage() === loadUploaded() AND S3File->exists()

### DIFF
--- a/code/s3/S3File.php
+++ b/code/s3/S3File.php
@@ -108,6 +108,16 @@ class S3File extends DataObject {
 		$this->S3 = new S3(self::$access_key, self::$secret_key);
 	}
 	
+	/**
+	 * A File exists if it has ID and S3 URL
+	 * Does not do any filesystem checks.
+	 * 
+	 * @return boolean
+	 */
+	public function exists() {
+		return parent::exists() && $this->URL;
+	}
+	
 	
 	/**
 	 * Sets a custom upload bucket for this instance. Overrides {@see self::$default_bucket}

--- a/code/s3/S3File.php
+++ b/code/s3/S3File.php
@@ -61,12 +61,6 @@ class S3File extends DataObject {
 	
 	
 	/**
-	 * @var string A custom filename
-	 */	
-	public $fileName = null;
-	
-	
-	/**
 	 * Set the two API keys needed to connect to S3
 	 *
 	 * @param string $access The access key
@@ -153,30 +147,25 @@ class S3File extends DataObject {
 	public function loadUploaded($filedata) {
 		if(!is_array($filedata) || !isset($filedata['tmp_name'])) 
 			return false;
-		
 		$fileTempName = $filedata['tmp_name'];
 		$fileName = $filedata['name'];
-		if(!$this->fileName) {
+		if(!$this->Name) {
 			$fileName = ereg_replace(' +','-',trim($fileName));
 			$fileName = ereg_replace('[^A-Za-z0-9.+_\-]','',$fileName);
-			if(self::$unique_id) {
-				$ext = File::get_file_extension($fileName);
-				$base = basename($fileName,".{$ext}");
-				$this->Name = uniqid($base).".{$ext}";
-			}
+			$ext = File::get_file_extension($fileName);
+			$this->Name = basename($fileName,".$ext");
+			if(self::$unique_id)
+				$this->Name .= uniqid('-');
+			$this->Name .= ".$ext";
 		}
-		else {
-			$this->Name = $this->fileName . "." . File::get_file_extension($fileName);
-		}
-
 		$bucket = $this->getUploadBucket();
-		$this->S3->putBucket($bucket, S3::ACL_PUBLIC_READ);
-
+		// TODO do a putBucket if it doesn't exist?
+		// $this->S3->putBucket($bucket, S3::ACL_PUBLIC_READ);
 		if ($this->S3->putObjectFile($fileTempName, $bucket, $this->Name, S3::ACL_PUBLIC_READ)) { 
 			$this->Bucket = $bucket;
 			$this->URL = "http://{$bucket}.s3.amazonaws.com/{$this->Name}";
+			return true;
 		}
-		
 		return false;
 	}
 	
@@ -187,11 +176,29 @@ class S3File extends DataObject {
 	 *
 	 * @return string
 	 */
-	public function Filename() {
+	public function getFilename() {
 		return basename($this->URL);
 	}
+	
+	/**
+	 * Getter for the "Filename" field. This is stored as a field for File, but here
+	 * it is done dynamically.
+	 *
+	 * @deprecated use S3File->getFilename() instead
+	 * @return string
+	 */
+	public function Filename() {
+		return $this->getFilename();
+	}
 
-
+	
+	/**
+	 * Get the URL of the cached S3Image
+	 * @return string
+	 */
+	public function getURL() {
+	    return isset($this->record['URL']) ? $this->record['URL'] : false;
+	}
 
 	
 	/**

--- a/code/s3/S3Image.php
+++ b/code/s3/S3Image.php
@@ -1,4 +1,5 @@
 <?php
+
 class S3Image extends S3File {
 	const ORIENTATION_SQUARE = 0;
 	const ORIENTATION_PORTRAIT = 1;
@@ -251,7 +252,8 @@ class S3Image extends S3File {
 				if($gd){
 
 					$bucket = $this->getUploadBucket();
-					$this->S3->putBucket($bucket, S3::ACL_PUBLIC_READ);
+					// TODO create bucket if it does not exist
+					// $this->S3->putBucket($bucket, S3::ACL_PUBLIC_READ);
 					$tempFile = tempnam (getTempFolder(), 's3images').File::get_file_extension ($cacheFile);
 					$gd->writeTo ($tempFile);
 					$this->S3->putObjectFile($tempFile, $bucket, '_resampled/'.basename ($cacheFile),
@@ -399,13 +401,13 @@ class S3Image extends S3File {
 class S3Image_Cached extends S3Image {
 	/**
 	 * Create a new cached image.
-	 * @param string $filename The filename of the image.
+	 * @param string $url The S3 URL of the image.
 	 * @param boolean $isSingleton This this to true if this is a singleton() object, a stub for calling methods.  Singletons
 	 * don't have their defaults set.
 	 */
-	public function __construct($filename = null, $isSingleton = false) {
+	public function __construct($url = null, $isSingleton = false) {
 		parent::__construct(array(), $isSingleton);
-		$this->Filename = $filename;
+		$this->URL = $url;
 	}
 	
 	public function getRelativePath() {
@@ -417,15 +419,7 @@ class S3Image_Cached extends S3Image {
 		
 	}
 	
-	/**
-	 * Get the URL of the cached S3Image
-	 * @return string
-	 */
-	public function getURL () {
-	    return $this->Filename;
-	}
-	
 	public function debug() {
-		return "S3Image_Cached object for $this->Filename";
+		return "S3Image_Cached object for $this->URL";
 	}
 }

--- a/code/s3/S3Image.php
+++ b/code/s3/S3Image.php
@@ -64,18 +64,6 @@ class S3Image extends S3File {
 		
 		parent::defineMethods();
 	}
-	
-	/**
-	 * An image exists if it has a filename.
-	 * Does not do any filesystem checks.
-	 * 
-	 * @return boolean
-	 */
-	public function exists() {
-		if(isset($this->record["Filename"])) {
-			return true;
-		}		
-	}
 
 	/**
 	 * Return an XHTML img tag for this Image,

--- a/code/s3/S3Image.php
+++ b/code/s3/S3Image.php
@@ -114,33 +114,7 @@ class S3Image extends S3File {
 	 * @return boolean
 	 */
 	function loadUploadedImage($filedata) {
-		if(!is_array($filedata) || !isset($filedata['tmp_name'])) 
-			return false;
-		
-		$fileTempName = $filedata['tmp_name'];
-		$fileName = $filedata['name'];
-		if(!$this->fileName) {
-			$fileName = ereg_replace(' +','-',trim($fileName));
-			$fileName = ereg_replace('[^A-Za-z0-9.+_\-]','',$fileName);
-			if(self::$unique_id) {
-				$ext = File::get_file_extension($fileName);
-				$base = basename($fileName,".{$ext}");
-				$this->Name = uniqid($base).".{$ext}";
-			}
-		}
-		else {
-			$this->Name = $this->fileName . "." . File::get_file_extension($fileName);
-		}
-
-		$bucket = $this->getUploadBucket();
-		$this->S3->putBucket($bucket, S3::ACL_PUBLIC_READ);
-
-		if ($this->S3->putObjectFile($fileTempName, $bucket, $this->Name, S3::ACL_PUBLIC_READ)) { 
-			$this->Bucket = $bucket;
-			$this->URL = "http://{$bucket}.s3.amazonaws.com/{$this->Name}";
-		}
-		
-		return false;
+		return $this->loadUploaded($filedata);
 	}
 	
 	public function SetWidth($width) {


### PR DESCRIPTION
loadUploadedImage() does _exactly_ the same as loadUploaded(), I see no point in having the same code twice

S3Image has an exists() function, which is broken (it checks for $this->record[Filename] but there is no Filename, there is only URL) and it makes little sence to have exists on S3Image but not on S3File
