### PR TITLE
Suggested FIX for IE 7-9.  If this field is used in conjunction with SS ...

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,5 +1,5 @@
 <?php
 
-if(isset($_POST['PHPSESSID'])) {
-	Session::start($_POST['PHPSESSID']);
+if(isset($_REQUEST['PHPSESSID'])) {
+	Session::start($_REQUEST['PHPSESSID']);
 }


### PR DESCRIPTION
...Member login, the PHPSession isn't updated when the Uploadify field is POSTed to the server (on the round trip AJAX return).  IE7-9 don't update the cookie, and the next POST that occurs will be out of sync with the server.  Checking REQUEST will also make sure the cookie is sent along with the POST, and will start the appropriate session on the server.
