### PR TITLE
Restrict upload to allowed file types only (2.4.x)

### DIFF
--- a/code/UploadifyField.php
+++ b/code/UploadifyField.php
@@ -305,8 +305,17 @@ abstract class UploadifyField extends FormField
 			$ext = strtolower(end(explode('.', $_FILES['Filedata']['name'])));
 			$class = in_array($ext, self::$image_extensions) ? $this->getSetting('image_class') : $this->getSetting('file_class');
 			$file = new $class();
+
+			// Perform check on allowed file extension, preventing upload of unallowed file types
 			$u = new Upload();
-			$u->loadIntoFile($_FILES['Filedata'], $file, $upload_folder);
+			$u->setValidator($validator = new Upload_Validator);
+			$validator->setAllowedExtensions(File::$allowed_extensions);
+			if($u->validate($_FILES['Filedata'])) {
+ 				$u->loadIntoFile($_FILES['Filedata'], $file, $upload_folder);
+			} else {
+       			return _t('Uploadify.FILETYPENOTALLOWED','File type not allowed!');
+			}
+			
 			$file->write();
 			if (method_exists($file, 'onAfterUpload')) $file->onAfterUpload();
 			echo $file->ID;

--- a/lang/nl_NL.php
+++ b/lang/nl_NL.php
@@ -22,3 +22,4 @@ $lang['nl_NL']['Uploadify']['UPLOADNEW'] = 'Nieuwe afbeeldingen uploaden';
 $lang['nl_NL']['Uploadify']['PLEASESELECT'] = 'Selecteer';
 $lang['nl_NL']['Uploadify']['DETATCH'] = 'Ontkoppel';
 $lang['nl_NL']['Uploadify']['DELETEPERMANENTLY'] = 'Verwijder permanent';
+$lang['nl_NL']['Uploadify']['FILETYPENOTALLOWED'] = 'Bestandstype niet toegestaan!';


### PR DESCRIPTION
If Uploadify module is used with SS 2.4.x it will replace upload functionality within the CMS.
This makes the system vulnerable. Once logged into the CMS a user can upload a .htaccess file or .php file and run it on the server. This fix will prevent that from happening. After trying to upload an unallowed file system will alert with message 'File type not allowed!'. Can be translated using i18n.
