### PR TITLE
Uploadify "HTTP Error" workaround

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,5 +1,5 @@
 <?php
 
-if(isset($_REQUEST['PHPSESSID'])) {
-	Session::start($_REQUEST['PHPSESSID']);
+if ($_SERVER['HTTP_USER_AGENT'] == 'Shockwave Flash' and isset($_POST['PHPSESSID'])) {
+	Session::start($_POST['PHPSESSID']);
 }


### PR DESCRIPTION
$_COOKIE has precedence over $_POST when $_REQUEST gets constructed,
so if flash uploader sends a bad PHPSESSID cookie, the bad
$_COOKIE['PHPSESSID'] was present in $_REQUEST, not the correct
$_POST['PHPSESSID']. Changing $_REQUEST to $_POST in _config.php
fixes this problem.
