### PR TITLE
Potential SQL Injection In FileUploadField

### DIFF
--- a/code/FileUploadField.php
+++ b/code/FileUploadField.php
@@ -110,7 +110,7 @@ class FileUploadField extends UploadifyField
 	public function Files() {
 		if($val = $this->Value()) {
 			$class = $this->baseFileClass;
-			if($files = DataObject::get($class, "\"{$class}\".\"ID\" IN (".Convert::raw2sql($val).")")) {
+			if($files = DataObject::get($class, "\"{$class}\".\"ID\" IN (".intval($val).")")) {
 				$ret = new DataObjectSet();
 				foreach($files as $file) {
 					if(is_subclass_of($file->ClassName, "Image") || $file->ClassName == "Image") {


### PR DESCRIPTION
It looks like Convert::raw2sql() is not enough for line 113 of FileUploadField, we received an error report from one of our monitored sites today emanating from FileUploadField that gave raised the concern.

Error: Couldn't run query: SELECT "File"."ClassName", "File"."Created", "File"."LastEdited", "File"."Name", "File"."Title", "File"."Filename", "File"."Content", "File"."Sort", "File"."ShowInSearch", "File"."SortOrder", "File"."ParentID", "File"."OwnerID", "File"."ID", CASE WHEN "File"."ClassName" IS NOT NULL THEN "File"."ClassName" ELSE 'File' END AS "RecordClassName" FROM "File" WHERE ("File"."ID" IN (8YEPUHjTwx)) ORDER BY "SortOrder" ASC Unknown column '8YEPUHjTwx' in 'where clause'
